### PR TITLE
fix(kairos): blacklist Longhorn multipath devices

### DIFF
--- a/kairos/overlays/role/k8s/README.md
+++ b/kairos/overlays/role/k8s/README.md
@@ -3,10 +3,11 @@
 Kubernetes node role overlay for K2 Kairos images.
 
 It bakes invariant K3s config under `/usr/share/k2/node-provision/k3s/`,
-time-sync service ordering, the unified persistent-storage cloud-config, and
-a persistent node-unique iSCSI initiator identity with `iscsid` enabled. The
-Dockerfile installs `k2-node-agent` plus the disk utilities and initrd contents
-declared in `overlay.yaml`.
+time-sync service ordering, the unified persistent-storage cloud-config, a
+persistent node-unique iSCSI initiator identity with `iscsid` enabled, and a
+multipath blacklist for Longhorn's single-path IET devices. The Dockerfile
+installs `k2-node-agent` plus the disk utilities and initrd contents declared in
+`overlay.yaml`.
 
 Kubernetes nodes require a dedicated non-boot `COS_PERSISTENT` disk. Their raw
 boot artifacts create only `COS_STATE`; the role disables Kairos' generic

--- a/kairos/overlays/role/k8s/oci/etc/multipath.conf
+++ b/kairos/overlays/role/k8s/oci/etc/multipath.conf
@@ -1,0 +1,13 @@
+defaults {
+    user_friendly_names yes
+}
+
+# Longhorn V1 volumes expose one IET path per attached volume. Treating those
+# single paths as multipath devices keeps the block device open and prevents
+# kubelet from mounting it.
+blacklist {
+    device {
+        vendor "IET"
+        product "VIRTUAL-DISK"
+    }
+}

--- a/kairos/overlays/role/k8s/overlay.yaml
+++ b/kairos/overlays/role/k8s/overlay.yaml
@@ -31,6 +31,10 @@ inspect:
           - "IPv4:"
           - '\4'
           - '\n'
+      - path: /etc/multipath.conf
+        contains:
+          - 'vendor "IET"'
+          - 'product "VIRTUAL-DISK"'
       - path: /usr/share/k2/node-provision/k3s/10-k2-invariant.yaml
         structuredTests:
           - op: test


### PR DESCRIPTION
## Summary
- blacklist Longhorn IET virtual disks from multipathd on K2 Kubernetes nodes
- verify the blacklist is present in built Kairos images
- document the node-image invariant

## Incident
Longhorn v1.12.0 exposed a latent node configuration issue during the CloudNativePG rollout: multipathd claimed newly attached Longhorn devices, causing NodeStageVolume to fail with mount point busy. The same blacklist has been applied live to all four nodes, and the CNPG primary recovered.

## Validation
- earthly +kairos-image-build-unit
- live CNPG cluster recovery and volume mount